### PR TITLE
Postcode import was timing out sometimes

### DIFF
--- a/app/code/community/Fontis/Australia/sql/australia_setup/mysql4-install-0.7.0.php
+++ b/app/code/community/Fontis/Australia/sql/australia_setup/mysql4-install-0.7.0.php
@@ -121,9 +121,7 @@ while ($row = fgets($fp)) {
 
 }
 //Import all values in a single expression and commit, _much_ faster and avoids timeouts on shared hosting accounts
-$installer->run("SET autocommit=0;
-                INSERT INTO {$this->getTable('au_postcode')} (postcode, city, region_code) VALUES ". $_values . ";
-                COMMIT;");
+$installer->run("INSERT INTO {$this->getTable('au_postcode')} (postcode, city, region_code) VALUES ". $_values . ";");
 
 fclose($fp);
 


### PR DESCRIPTION
The whole module install was failing on shared hosting due to the thousands of inserts to load in the postcode data file. Moving it all into a single large insert statement dramatically sped it up
