### PR TITLE
str_pad breaks lookups for postcodes under 1000

### DIFF
--- a/src/app/code/community/Fontis/Australia/Model/Mysql4/Shipping/Carrier/Eparcel.php
+++ b/src/app/code/community/Fontis/Australia/Model/Mysql4/Shipping/Carrier/Eparcel.php
@@ -350,7 +350,7 @@ class Fontis_Australia_Model_Mysql4_Shipping_Carrier_Eparcel extends Mage_Core_M
                             
                             Mage::log(var_export($postcodes, true));
                             foreach($postcodes as $postcode) {
-                                $dataLine['dest_zip'] = str_pad($postcode, 4, "0", STR_PAD_LEFT);
+                                $dataLine['dest_zip'] = $postcode;
                                 $connection->insert($table, $dataLine);
                             }
                         } catch (Exception $e) {


### PR DESCRIPTION
With postcodes under 1000, lookups don't work. This is because the database stores the postcode 800 as '0800', and the lookup at time of calculating shipping options selects where dest_zip='800'.

I've removed the str_pad so solve this issue. The other option would be to pad during lookup. I'm not sure what the value is in padding it out as input time though.
