### PR TITLE
Update Eparcel.php

### DIFF
--- a/src/app/code/community/Fontis/Australia/Model/Mysql4/Shipping/Carrier/Eparcel.php
+++ b/src/app/code/community/Fontis/Australia/Model/Mysql4/Shipping/Carrier/Eparcel.php
@@ -304,8 +304,8 @@ class Fontis_Australia_Model_Mysql4_Shipping_Carrier_Eparcel extends Mage_Core_M
                             'price' => $csvLine[5],
                             'price_per_kg' => $csvLine[6],
                             'delivery_type' => $csvLine[7],
-                            'charge_codes_individual' => $csvLine[8],
-                            'charge_codes_business' => $csvLine[9]
+                            'charge_code_individual' => $csvLine[8],
+                            'charge_code_business' => $csvLine[9]
                         );
                         
                         $dataDetails[] = array(


### PR DESCRIPTION
https://github.com/fontis/fontis_australia/issues/28
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'charge_codes_individual' in 'field list' while importing csv from admin

Made changes in line  296
$data[] = array(
'website_id' => $websiteId,
'dest_country_id' => $countryId,
'dest_region_id' => $regionId,
'dest_zip' => $zip,
'condition_name' => $conditionName,
'condition_from_value' => $csvLine[3],
'condition_to_value' => $csvLine[4],
'price' => $csvLine[5],
'price_per_kg' => $csvLine[6],
'delivery_type' => $csvLine[7],
'charge_code_individual' => $csvLine[8],
'charge_code_business' => $csvLine[9]
);
