### PR TITLE
Add epracel code fields to core shipping methods freeshipping and flatra...

### DIFF
--- a/src/app/code/community/Fontis/Australia/Model/Shipping/Carrier/Eparcel/Export/Csv.php
+++ b/src/app/code/community/Fontis/Australia/Model/Shipping/Carrier/Eparcel/Export/Csv.php
@@ -262,6 +262,13 @@ extends Fontis_Australia_Model_Shipping_Carrier_Eparcel_Export_Abstract
     
     protected function _getChargeCode(Mage_Sales_Model_Order $order)
     {
+        
+        if($shippingCarrier = $order->getShippingCarrier()) {
+           if($shippingCarrier->getConfigData('eparcel_code')) {
+               return $shippingCarrier->getConfigData('eparcel_code');
+           }
+        }
+        
         list ($carrierCode, $chargeCode) = explode('_', $order->getData('shipping_method'));
         
         if ($this->_isValidChargeCode($chargeCode)) {

--- a/src/app/code/community/Fontis/Australia/etc/system.xml
+++ b/src/app/code/community/Fontis/Australia/etc/system.xml
@@ -30,6 +30,30 @@
     <sections>
         <carriers>
             <groups>
+                <flatrate translate="label">
+                    <fields>
+                        <eparcel_code translate="label">
+                            <label>Eparcel Code</label>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>5000</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </eparcel_code>
+                    </fields>
+                </flatrate>
+                <freeshipping translate="label">
+                    <fields>
+                        <eparcel_code translate="label">
+                            <label>Eparcel Code</label>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>5000</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </eparcel_code>
+                    </fields>
+                </freeshipping>
                 <australiapost translate="label" module="australia">
                     <label>Australia Post</label>
                     <frontend_type>text</frontend_type>


### PR DESCRIPTION
By default it would seem the eparcel code only work for table rates.

If a customer configures core flatrate as Express Parcel, and free shipping for Standard Parcel, they will both export using the default configured parcel code (sine they are not part of the table rate carrier option)

Since this is incorrect, I have added a field to both the carriers, called 'eParcel Code', with code that will export those codes if configured, or else it will use the defaults.

This then allows the core carriers to be used for individual eparcel shipping method.
