### PR TITLE
Update eParcel payload for strict MySQL

### DIFF
--- a/src/app/code/community/Fontis/Australia/Model/Mysql4/Shipping/Carrier/Eparcel.php
+++ b/src/app/code/community/Fontis/Australia/Model/Mysql4/Shipping/Carrier/Eparcel.php
@@ -302,7 +302,7 @@ class Fontis_Australia_Model_Mysql4_Shipping_Carrier_Eparcel extends Mage_Core_M
                         if (isset($csvLine[10]) && intval($csvLine[10]) < 0) {
                             $exceptions[] = Mage::helper('shipping')->__('Invalid Warehouse ID "%s" in the Row #%s', $csvLine[10], ($k+1));
                         } else {
-                            $csvLine[10] = isset($csvLine[10]) ? (int)$csvLine[10] : null;
+                            $csvLine[10] = isset($csvLine[10]) ? (int)$csvLine[10] : 0;
                         }
 
                         $data[] = array(


### PR DESCRIPTION
Some MySQL servers will throw an exception in the way Magento inserts "null" data. Some servers will throw the following exception:

```
An error occurred while saving this configuration: SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'stock_id' cannot be null
```

By passing an integer, we are sticking with the schema (which is a non-null integer). The alternative is to bump the version and make the field nullable.