### PR TITLE
Fixes rejection of valid eParcel charge codes

### DIFF
--- a/src/app/code/community/Fontis/Australia/Helper/Eparcel.php
+++ b/src/app/code/community/Fontis/Australia/Helper/Eparcel.php
@@ -120,7 +120,11 @@ class Fontis_Australia_Helper_Eparcel extends Mage_Core_Helper_Abstract
     {
         $isStandard = in_array($chargeCode, $this->standardChargeCodes);
 
-        if (!$isStandard && Mage::getStoreConfigFlag('doghouse_eparcelexport/charge_codes/allow_custom_charge_codes')) {
+        if ($isStandard)
+        {
+            return true;
+        }
+        elseif (!$isStandard && Mage::getStoreConfigFlag('doghouse_eparcelexport/charge_codes/allow_custom_charge_codes')) {
             // Charge code not found in the standard list of codes, but system config tells us this is OK
             // @see https://github.com/fontis/fontis_australia/issues/39
             return true;


### PR DESCRIPTION
After changes made in issue #39 valid charge codes are now rejected.

fixes #52

Regards
Geoff
