### PR TITLE
Add ability to do city lookup matching from start of name only

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://www.fontis.com.au/australia-magento-extension",
     "require": {
         "magento-hackathon/magento-composer-installer": "*",
-        "fontis/auspost-api-php": "1.x",
+        "proxiblue/auspost-api-php": "1.x",
         "fontis/composer-autoloader": "*"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "fontis/australia",
+    "name": "proxiblue/australia",
     "type": "magento-module",
     "license": "OSL-3.0",
     "description": "Magento extension that provides functionality for Australian stores.",

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://www.fontis.com.au/australia-magento-extension",
     "require": {
         "magento-hackathon/magento-composer-installer": "*",
-        "proxiblue/auspost-api-php": "1.x",
+        "fontis/auspost-api-php": "1.x",
         "fontis/composer-autoloader": "*"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "proxiblue/australia",
+    "name": "fontis/australia",
     "type": "magento-module",
     "license": "OSL-3.0",
     "description": "Magento extension that provides functionality for Australian stores.",

--- a/src/app/code/community/Fontis/Australia/Helper/Data.php
+++ b/src/app/code/community/Fontis/Australia/Helper/Data.php
@@ -112,6 +112,9 @@ class Fontis_Australia_Helper_Data extends Mage_Core_Helper_Abstract
             return array();
         }
 
+        $cityQueryTet = (Mage::getStoreConfig("fontis_australia/postcode_autocomplete/match_start"))
+            ? $this->getQueryText() : '%' . $this->getQueryText();
+
         $res = Mage::getSingleton('core/resource');
         /* @var $conn Varien_Db_Adapter_Pdo_Mysql */
         $conn = $res->getConnection('australia_read');
@@ -120,7 +123,7 @@ class Fontis_Australia_Helper_Data extends Mage_Core_Helper_Abstract
              INNER JOIN ' . $res->getTableName('directory_country_region') . ' AS dcr ON au.region_code = dcr.code
              WHERE city LIKE :city ORDER BY city, region_code, postcode
              LIMIT ' . $this->getPostcodeAutocompleteMaxResults(),
-            array('city' => '%' . $this->getQueryText() . '%')
+            array('city' => $cityQueryTet . '%')
         );
     }
 }

--- a/src/app/code/community/Fontis/Australia/etc/system.xml
+++ b/src/app/code/community/Fontis/Australia/etc/system.xml
@@ -783,6 +783,15 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </max_results>
+                        <match_start translate="label">
+                            <label>Match 'Starts with'</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>15</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </match_start>
                     </fields>
                 </postcode_autocomplete>
                 <address_validation translate="label">


### PR DESCRIPTION
The current way is to do a LIKE mathcing any part.
Add ability to match only from start, thus limiting results to a more direct/accurate list

Option can be enabled via admin