### PR TITLE
  Replaced signature on delivery options from yes/no to new auspost codes

### DIFF
--- a/src/app/code/community/Fontis/Australia/Model/Shipping/Carrier/Eparcel/Export/Csv.php
+++ b/src/app/code/community/Fontis/Australia/Model/Shipping/Carrier/Eparcel/Export/Csv.php
@@ -195,7 +195,7 @@ class Fontis_Australia_Model_Shipping_Carrier_Eparcel_Export_Csv extends Fontis_
 
         $consignmentRecord->chargeCode = $this->_getChargeCode($order);
 
-        $consignmentRecord->isSignatureRequired    = (bool) $this->getDefault('consignement/is_signature_required');
+        $consignmentRecord->isSignatureRequired    = $this->getDefault('consignement/is_signature_required');
         $consignmentRecord->addToAddressBook       = (bool) $this->getDefault('consignement/add_to_address_book');
         $consignmentRecord->isRefPrintRequired     = (bool) $this->getDefault('consignement/print_ref1');
         $consignmentRecord->isRef2PrintRequired    = (bool) $this->getDefault('consignement/print_ref2');

--- a/src/app/code/community/Fontis/Australia/Model/Shipping/Carrier/Source/Signatureoptions.php
+++ b/src/app/code/community/Fontis/Australia/Model/Shipping/Carrier/Source/Signatureoptions.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Used for Australia Post configuration fields that need the options "never",
+ * "required" and "optional"
+ */
+class Fontis_Australia_Model_Shipping_Carrier_Australiapost_Source_Signatureoptions
+{
+    const AUTHORITY_LEAVE = 'Y';
+    const AUTHORITY_LEAVE_REQUEST = 'R';
+    const REQUIRED = 'A';
+
+    /**
+     * Options getter
+     *
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        $helper = Mage::helper('australia');
+        return array(
+            array('value' => self::AUTHORITY_LEAVE, 'label' => $helper->__('Authority To Leave')),
+            array('value' => self::AUTHORITY_LEAVE_REQUEST, 'label' => $helper->__('Authority To leave can be requested')),
+            array('value' => self::REQUIRED,    'label' => $helper->__('Signature required')),
+        );
+    }
+
+    /**
+     * Get options in "key-value" format
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        $helper = Mage::helper('australia');
+        return array(
+            self::AUTHORITY_LEAVE    => $helper->__('Authority To Leave'),
+            self::AUTHORITY_LEAVE_REQUEST => $helper->__('Authority To leave can be requested'),
+            self::REQUIRED => $helper->__('Signature required'),
+        );
+    }
+}

--- a/src/app/code/community/Fontis/Australia/etc/system.xml
+++ b/src/app/code/community/Fontis/Australia/etc/system.xml
@@ -235,7 +235,7 @@
                         <signature_required translate="label">
                             <label>Signature Required</label>
                             <frontend_type>select</frontend_type>
-                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <source_model>australia/shipping_carrier_australiapost_source_signatureoptions</source_model>
                             <sort_order>12</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -1126,7 +1126,7 @@
                         <is_signature_required translate="label">
                             <label>Is Signature Required ?</label>
                             <frontend_type>select</frontend_type>
-                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <source_model>australia/shipping_carrier_australiapost_source_signatureoptions</source_model>
                             <sort_order>10</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>


### PR DESCRIPTION
In reply to issue #64 
This is capital so that the exported consignment sheet complies to auspost latest standards